### PR TITLE
feat: 학생 태그 DB 생성

### DIFF
--- a/Idam/src/main/java/com/team7/Idam/config/TagDataInitializer.java
+++ b/Idam/src/main/java/com/team7/Idam/config/TagDataInitializer.java
@@ -1,0 +1,119 @@
+package com.team7.Idam.config;
+
+import com.team7.Idam.domain.user.entity.TagCategory;
+import com.team7.Idam.domain.user.entity.TagOption;
+import com.team7.Idam.domain.user.entity.Student;
+import com.team7.Idam.domain.user.repository.TagCategoryRepository;
+import com.team7.Idam.domain.user.repository.TagOptionRepository;
+import com.team7.Idam.domain.user.repository.StudentRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class TagDataInitializer implements CommandLineRunner {
+
+    private final TagCategoryRepository tagCategoryRepository;
+    private final TagOptionRepository tagOptionRepository;
+    private final StudentRepository studentRepository;
+
+    @Override
+    public void run(String... args) {
+        // 1. 카테고리 생성
+        TagCategory itCategory = new TagCategory();
+        itCategory.setCategoryName("IT·프로그래밍");
+        tagCategoryRepository.save(itCategory);
+
+        TagCategory design = new TagCategory();
+        design.setCategoryName("디자인");
+        tagCategoryRepository.save(design);
+
+        TagCategory marketing = new TagCategory();
+        marketing.setCategoryName("마케팅");
+        tagCategoryRepository.save(marketing);
+
+        // 2. 태그 생성
+
+        // itCategory Tags
+        TagOption javaTag = new TagOption();
+        javaTag.setTagName("Java");
+        javaTag.setCategory(itCategory);
+        tagOptionRepository.save(javaTag);
+
+        TagOption springTag = new TagOption();
+        springTag.setTagName("Spring");
+        springTag.setCategory(itCategory);
+        tagOptionRepository.save(springTag);
+
+        TagOption reactTag = new TagOption();
+        reactTag.setTagName("React");
+        reactTag.setCategory(itCategory);
+        tagOptionRepository.save(reactTag);
+
+        TagOption typescriptTag = new TagOption();
+        typescriptTag.setTagName("Typescript");
+        typescriptTag.setCategory(itCategory);
+        tagOptionRepository.save(typescriptTag);
+
+        TagOption sqlTag = new TagOption();
+        sqlTag.setTagName("SQL");
+        sqlTag.setCategory(itCategory);
+        tagOptionRepository.save(sqlTag);
+
+        // design Tags
+        TagOption adobePhotoshopTag = new TagOption();
+        adobePhotoshopTag.setTagName("Adobe Photoshop");
+        adobePhotoshopTag.setCategory(design);
+        tagOptionRepository.save(adobePhotoshopTag);
+
+        TagOption adobeIllustratorTag = new TagOption();
+        adobeIllustratorTag.setTagName("Adobe Illustrator");
+        adobeIllustratorTag.setCategory(design);
+        tagOptionRepository.save(adobeIllustratorTag);
+
+        TagOption figmaTag = new TagOption();
+        figmaTag.setTagName("Figma");
+        figmaTag.setCategory(design);
+        tagOptionRepository.save(figmaTag);
+
+        // marketing Tags
+        TagOption ShoppingMallOperationTag = new TagOption();
+        ShoppingMallOperationTag.setTagName("ShoppingMall Operation");
+        ShoppingMallOperationTag.setCategory(marketing);
+        tagOptionRepository.save(ShoppingMallOperationTag);
+
+        TagOption SNSManagementTag = new TagOption();
+        SNSManagementTag.setTagName("SNS Management");
+        SNSManagementTag.setCategory(marketing);
+        tagOptionRepository.save(SNSManagementTag);
+
+        TagOption CPAMarketingTag = new TagOption();
+        CPAMarketingTag.setTagName("CPA Marketing");
+        CPAMarketingTag.setCategory(marketing);
+        tagOptionRepository.save(CPAMarketingTag);
+
+        // 3. 테스트 학생에 태그 연결
+        Student student1 = studentRepository.findById(1L).orElse(null);
+        if (student1 != null) {
+            student1.getTags().addAll(List.of(javaTag, springTag, sqlTag));
+            studentRepository.save(student1);
+        }
+        Student student2 = studentRepository.findById(2L).orElse(null);
+        if (student2 != null) {
+            student2.getTags().addAll(List.of(adobePhotoshopTag, adobeIllustratorTag));
+            studentRepository.save(student2);
+        }
+        Student student3 = studentRepository.findById(3L).orElse(null);
+        if (student3 != null) {
+            student3.getTags().addAll(List.of(SNSManagementTag, CPAMarketingTag));
+            studentRepository.save(student3);
+        }
+
+        System.out.println("✅ TagInitializer: 더미 데이터 초기화 완료!");
+    }
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/entity/Student.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/entity/Student.java
@@ -4,6 +4,9 @@ import com.team7.Idam.domain.user.entity.enums.Gender;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "student")
 @Getter
@@ -46,4 +49,12 @@ public class Student {
     @Enumerated(EnumType.STRING)
     @Column(nullable = true, length = 10)
     private Gender gender;
+
+    @ManyToMany
+    @JoinTable(
+            name = "student_tag",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private List<TagOption> tags = new ArrayList<>();
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/entity/TagCategory.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/entity/TagCategory.java
@@ -1,0 +1,25 @@
+package com.team7.Idam.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "tag_category")
+@Getter
+@Setter
+@NoArgsConstructor
+public class TagCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+
+    @Column(nullable = false, length = 100)
+    private String categoryName;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
+    private List<TagOption> tagOptions = new ArrayList<>();
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/entity/TagOption.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/entity/TagOption.java
@@ -1,0 +1,29 @@
+package com.team7.Idam.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "tag_option")
+@Getter
+@Setter
+@NoArgsConstructor
+public class TagOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long tagId;
+
+    @Column(nullable = false, length = 100)
+    private String tagName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private TagCategory category;
+
+    @ManyToMany(mappedBy = "tags")
+    private List<Student> students = new ArrayList<>();
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/repository/TagCategoryRepository.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/repository/TagCategoryRepository.java
@@ -1,0 +1,9 @@
+package com.team7.Idam.domain.user.repository;
+
+import com.team7.Idam.domain.user.entity.TagCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagCategoryRepository extends JpaRepository<TagCategory, Long> {
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/repository/TagOptionRepository.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/repository/TagOptionRepository.java
@@ -1,0 +1,9 @@
+package com.team7.Idam.domain.user.repository;
+
+import com.team7.Idam.domain.user.entity.TagOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagOptionRepository extends JpaRepository<TagOption, Long> {
+}


### PR DESCRIPTION
### 1. 학생 태그용 DB 생성.
student_tag
├── N:1 → Student
└── N:1 → tag_option
                          └── N:1 → tag_category

### 2. 학생 태그 더미데이터 생성.
- IT·프로그래밍(itCategory)
  - java
  - spring
  - react
  - typescript
  - sql
- 디자인(design)
  - adobePhotoshop
  - adobeIllustrator
  - figma
- 마케팅(marketing)
  - ShoppingMallOperation
  - SNSManagement
  - CPAMarketing

-> 마케팅 태그 카멜 표기법 미적용.. (추후 디벨롭?)
-> 각 태그 및 카테고리 더미 생성 -> 서버 저장으로 리팩터링 고려