### PR TITLE
refactor: 학생/기업 로그인 로직 통합

### DIFF
--- a/Idam/src/main/java/com/team7/Idam/config/TagDataInitializer.java
+++ b/Idam/src/main/java/com/team7/Idam/config/TagDataInitializer.java
@@ -82,10 +82,10 @@ public class TagDataInitializer implements CommandLineRunner {
         tagOptionRepository.save(figmaTag);
 
         // marketing Tags
-        TagOption ShoppingMallOperationTag = new TagOption();
-        ShoppingMallOperationTag.setTagName("ShoppingMall Operation");
-        ShoppingMallOperationTag.setCategory(marketing);
-        tagOptionRepository.save(ShoppingMallOperationTag);
+        TagOption shoppingMallOperationTag = new TagOption();
+        shoppingMallOperationTag.setTagName("ShoppingMall Operation");
+        shoppingMallOperationTag.setCategory(marketing);
+        tagOptionRepository.save(shoppingMallOperationTag);
 
         TagOption SNSManagementTag = new TagOption();
         SNSManagementTag.setTagName("SNS Management");

--- a/Idam/src/main/java/com/team7/Idam/domain/user/controller/AuthController.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/controller/AuthController.java
@@ -37,20 +37,17 @@ public class AuthController {
         return ResponseEntity.ok("기업 회원가입이 완료되었습니다.");
     }
 
-    // 학생 로그인
-    @PostMapping("/api/login/student")
-    public ResponseEntity<LoginResponseDto> loginStudent(@Valid @RequestBody LoginRequestDto request, HttpServletResponse response) {
-        LoginResultDto loginResult = authService.loginStudent(request);
+    // 로그인
+    @PostMapping("/api/login")
+    public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto request, HttpServletResponse response) {
+        LoginResultDto loginResult = authService.login(request);
         addRefreshTokenToCookie(response, loginResult.getRefreshToken());
-        return ResponseEntity.ok(new LoginResponseDto(loginResult.getAccessToken(), loginResult.getUserType()));
-    }
-
-    // 기업 로그인
-    @PostMapping("/api/login/company")
-    public ResponseEntity<LoginResponseDto> loginCompany(@Valid @RequestBody LoginRequestDto request, HttpServletResponse response) {
-        LoginResultDto loginResult = authService.loginCompany(request);
-        addRefreshTokenToCookie(response, loginResult.getRefreshToken());
-        return ResponseEntity.ok(new LoginResponseDto(loginResult.getAccessToken(), loginResult.getUserType()));
+        return ResponseEntity.ok(
+                new LoginResponseDto(
+                        loginResult.getAccessToken(),
+                        loginResult.getUserType()
+                )
+        );
     }
 
     // 로그아웃

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/signup/CompanySignupRequestDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/signup/CompanySignupRequestDto.java
@@ -39,7 +39,6 @@ public class CompanySignupRequestDto {
     @Size(max = 20)
     private String phone;
 
-    @NotBlank
     @Size(max = 255)
     private String profileImage;
 }


### PR DESCRIPTION
기존에 분리되어 있던 학생 로그인 / 기업 로그인 로직을 하나의 로그인 서비스로 병합.
### 주요 변경 클래스
- AuthController
- AuthService


(+ 추가 리팩터링)
- 학생 태그 더미데이터 -> marketing Tag의 shoppingMallOperationTag 카멜 표기법 적용.
- 기업 회원가입 시, 프로필 이미지의 빈칸 허용. (= 필수X)
