### PR TITLE
feat: 학생 프로필 관리 API 구현

### DIFF
--- a/Idam/src/main/java/com/team7/Idam/config/SecurityConfig.java
+++ b/Idam/src/main/java/com/team7/Idam/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.team7.Idam.config;
 
-import com.team7.Idam.jwt.JwtRefreshAuthenticationFilter;
+import com.team7.Idam.domain.user.repository.UserRepository;
 import com.team7.Idam.jwt.JwtTokenProvider;
 import com.team7.Idam.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +19,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
 
     // BCrypt >> 비밀번호를 "단방향 해시"로 안전하게 변환해주는 암호화 알고리즘
     @Bean
@@ -26,24 +27,23 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
+    // SecurityFilterChain
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        // accessToken 검증 필터 (refresh, logout 경로는 검증 스킵하도록 내부에 작성함)
-        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider);
-        // refreshToken 검증 필터 (refresh, logout 경로만 검증하도록 내부에 작성함)
-        JwtRefreshAuthenticationFilter jwtRefreshAuthenticationFilter = new JwtRefreshAuthenticationFilter(jwtTokenProvider);
-
         return http
+                // CSRF 토큰 검증 비활성화(-> JWT토큰으로 대체)
                 .csrf(csrf -> csrf.disable())
+                // 경로별로 접근 허용 여부 설정
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/signup/**", "/api/login/**").permitAll()
-                        .requestMatchers("/api/refresh", "/api/logout").permitAll()
-                        .anyRequest().authenticated()
+                        .requestMatchers(
+                                "/api/signup/**",   // 회원가입 허용
+                                "/api/login/**",    // 로그인 허용
+                                "/api/refresh"      // 토큰 재발급 허용
+                        ).permitAll() // 누구나 요청 허용
+                        .anyRequest().authenticated()  // 나머지는 인증 필요
                 )
-                // refreshToken 검증 필터 → accessToken 검증 필터보다 먼저 동작
-                .addFilterBefore(jwtRefreshAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                // accessToken 검증 필터 (refresh, logout 경로는 이 필터 안에서 스킵)
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                // 기본 필터 앞에 JWT 검증 필터 삽입
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userRepository), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 

--- a/Idam/src/main/java/com/team7/Idam/domain/user/controller/StudentProfileController.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/controller/StudentProfileController.java
@@ -1,0 +1,67 @@
+package com.team7.Idam.domain.user.controller;
+
+import com.team7.Idam.domain.user.dto.profile.PortfolioRequestDto;
+import com.team7.Idam.domain.user.dto.profile.StudentProfileResponseDto;
+import com.team7.Idam.domain.user.dto.profile.StudentProfileUpdateRequestDto;
+import com.team7.Idam.domain.user.service.StudentProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/students")
+@RequiredArgsConstructor
+public class StudentProfileController {
+
+    private final StudentProfileService studentService;
+
+    // 프로필 조회
+    @GetMapping("/{studentId}/profile")
+    public StudentProfileResponseDto getStudentProfile(@PathVariable Long studentId) {
+        return studentService.getStudentProfile(studentId);
+    }
+
+    // 프로필 수정
+    @PutMapping("/{studentId}/profile")
+    public ResponseEntity<String> updateStudentProfile(@PathVariable Long studentId, @RequestBody StudentProfileUpdateRequestDto request) {
+        studentService.updateStudentProfile(studentId, request);
+        return ResponseEntity.ok().body("프로필이 수정되었습니다.");
+    }
+
+    // 포트폴리오 추가
+    @PostMapping("/{studentId}/portfolios")
+    public ResponseEntity<String> addPortfolio(@PathVariable Long studentId, @RequestBody PortfolioRequestDto request) {
+        studentService.addPortfolio(studentId, request);
+        return ResponseEntity.ok().body("포트폴리오가 추가되었습니다.");
+    }
+
+    // 포트폴리오 삭제
+    @DeleteMapping("/{studentId}/portfolios/{portfolioId}")
+    public ResponseEntity<String> deletePortfolio(@PathVariable Long studentId, @PathVariable Long portfolioId) {
+        studentService.deletePortfolio(studentId, portfolioId);
+        return ResponseEntity.ok().body("포트폴리오가 삭제되었습니다.");
+    }
+
+    // 태그 추가
+    @PostMapping("/{studentId}/tags/{tagId}")
+    public ResponseEntity<String> addStudentTag(@PathVariable Long studentId, @PathVariable Long tagId) {
+        studentService.addStudentTag(studentId, tagId);
+        return ResponseEntity.ok("태그가 추가되었습니다.");
+    }
+
+    // 태그 수정
+    @PutMapping("/{studentId}/tags")
+    public ResponseEntity<String> updateStudentTags(@PathVariable Long studentId, @RequestBody List<Long> tagIds) {
+        studentService.updateStudentTags(studentId, tagIds);
+        return ResponseEntity.ok("태그가 수정되었습니다.");
+    }
+
+    // 태그 삭제
+    @DeleteMapping("/{studentId}/tags/{tagId}")
+    public ResponseEntity<String> removeStudentTag(@PathVariable Long studentId, @PathVariable Long tagId) {
+        studentService.removeStudentTag(studentId, tagId);
+        return ResponseEntity.ok("태그가 삭제되었습니다.");
+    }
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/PortfolioRequestDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/PortfolioRequestDto.java
@@ -1,0 +1,8 @@
+package com.team7.Idam.domain.user.dto.profile;
+
+import lombok.Data;
+
+@Data
+public class PortfolioRequestDto {
+    private String portfolio;
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/StudentProfileResponseDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/StudentProfileResponseDto.java
@@ -1,0 +1,19 @@
+package com.team7.Idam.domain.user.dto.profile;
+
+import com.team7.Idam.domain.user.entity.enums.Gender;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class StudentProfileResponseDto {
+    private String name;
+    private String schoolName;
+    private String major;
+    private String schoolId;
+    private String nickname;
+    private Gender gender;
+    private String profileImage;
+    private String email;
+    private String phone;
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/StudentProfileUpdateRequestDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/StudentProfileUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package com.team7.Idam.domain.user.dto.profile;
+
+import com.team7.Idam.domain.user.entity.enums.Gender;
+import lombok.Data;
+
+@Data
+public class StudentProfileUpdateRequestDto {
+    private String nickname;
+    private Gender gender;
+    private String profileImage;
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/entity/Portfolio.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/entity/Portfolio.java
@@ -4,7 +4,11 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "portfolio")
+@Table(
+        name = "portfolio",
+        // 학생별 동일 포트폴리오 추가 방지
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "portfolio"})}
+)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -22,5 +26,5 @@ public class Portfolio {
     private Student student;
 
     @Column(length = 255, nullable = false)
-    private String portfolio; // 실제 저장된 파일 경로나 URL
+    private String portfolio;
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/repository/PortfolioRepository.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/repository/PortfolioRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
-    List<Portfolio> findByStudentId(Long studentId);
+    boolean existsByStudentIdAndPortfolio(Long studentId, String portfolio);
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/service/StudentProfileService.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/service/StudentProfileService.java
@@ -1,0 +1,148 @@
+package com.team7.Idam.domain.user.service;
+
+import com.team7.Idam.domain.user.dto.profile.PortfolioRequestDto;
+import com.team7.Idam.domain.user.dto.profile.StudentProfileResponseDto;
+import com.team7.Idam.domain.user.dto.profile.StudentProfileUpdateRequestDto;
+import com.team7.Idam.domain.user.entity.Portfolio;
+import com.team7.Idam.domain.user.entity.Student;
+import com.team7.Idam.domain.user.entity.TagOption;
+import com.team7.Idam.domain.user.repository.PortfolioRepository;
+import com.team7.Idam.domain.user.repository.StudentRepository;
+import com.team7.Idam.domain.user.repository.TagOptionRepository;
+import com.team7.Idam.jwt.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StudentProfileService {
+
+    private final StudentRepository studentRepository;
+    private final PortfolioRepository portfolioRepository;
+    private final TagOptionRepository tagOptionRepository;
+
+    // 학생 프로필 조회
+    public StudentProfileResponseDto getStudentProfile(Long studentId) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 학생을 찾을 수 없습니다."));
+
+        return StudentProfileResponseDto.builder()
+                .name(student.getName())
+                .schoolName(student.getSchoolName())
+                .major(student.getMajor())
+                .schoolId(student.getSchoolId())
+                .nickname(student.getNickname())
+                .gender(student.getGender())
+                .profileImage(student.getProfileImage())
+                .email(student.getUser().getEmail())
+                .phone(student.getUser().getPhone())
+                .build();
+    }
+
+    // 학생 프로필 수정
+    public void updateStudentProfile(Long studentId, StudentProfileUpdateRequestDto request) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 학생을 찾을 수 없습니다."));
+
+        Long currentUserId = getCurrentUserId();  // JWT에서 추출
+        if (!student.getUser().getId().equals(currentUserId)) {
+            throw new AccessDeniedException("본인만 수정할 수 있습니다.");
+        }
+
+        if (request.getNickname() != null) {
+            student.setNickname(request.getNickname());
+        }
+        if (request.getGender() != null) {
+            student.setGender(request.getGender());
+        }
+        if (request.getProfileImage() != null) {
+            student.setProfileImage(request.getProfileImage());
+        }
+
+        studentRepository.save(student);
+    }
+
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getId();
+    }
+
+    // 포트폴리오 추가
+    public void addPortfolio(Long studentId, PortfolioRequestDto request) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다."));
+
+        boolean exists = portfolioRepository.existsByStudentIdAndPortfolio(studentId, request.getPortfolio());
+        if (exists) {
+            throw new IllegalArgumentException("이미 동일한 포트폴리오가 등록되어 있습니다.");
+        }
+
+        Portfolio portfolio = Portfolio.builder()
+                .student(student)
+                .portfolio(request.getPortfolio())
+                .build();
+
+        portfolioRepository.save(portfolio);
+    }
+
+    // 포트폴리오 삭제
+    public void deletePortfolio(Long studentId, Long portfolioId) {
+        Portfolio portfolio = portfolioRepository.findById(portfolioId)
+                .orElseThrow(() -> new IllegalArgumentException("포트폴리오를 찾을 수 없습니다."));
+
+        if (!portfolio.getStudent().getId().equals(studentId)) {
+            throw new SecurityException("본인만 삭제할 수 있습니다.");
+        }
+
+        portfolioRepository.delete(portfolio);
+    }
+
+    // 태그 추가
+    public void addStudentTag(Long studentId, Long tagId) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다."));
+
+        TagOption tag = tagOptionRepository.findById(tagId)
+                .orElseThrow(() -> new IllegalArgumentException("태그를 찾을 수 없습니다."));
+
+        if (student.getTags().contains(tag)) {
+            throw new IllegalArgumentException("이미 추가된 태그입니다.");
+        }
+
+        student.getTags().add(tag);
+        studentRepository.save(student);
+    }
+
+    // 태그 수정
+    public void updateStudentTags(Long studentId, List<Long> tagIds) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다."));
+
+        List<TagOption> newTags = tagOptionRepository.findAllById(tagIds);
+
+        student.setTags(newTags);
+        studentRepository.save(student);
+    }
+
+    // 태그 삭제
+    public void removeStudentTag(Long studentId, Long tagId) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다."));
+
+        TagOption tag = tagOptionRepository.findById(tagId)
+                .orElseThrow(() -> new IllegalArgumentException("태그를 찾을 수 없습니다."));
+
+        if (!student.getTags().contains(tag)) {
+            throw new IllegalArgumentException("학생에게 해당 태그가 존재하지 않습니다.");
+        }
+
+        student.getTags().remove(tag);
+        studentRepository.save(student);
+    }
+}

--- a/Idam/src/main/java/com/team7/Idam/jwt/CustomUserDetails.java
+++ b/Idam/src/main/java/com/team7/Idam/jwt/CustomUserDetails.java
@@ -1,0 +1,51 @@
+package com.team7.Idam.jwt;
+
+import com.team7.Idam.domain.user.entity.User;
+import com.team7.Idam.domain.user.entity.enums.UserType;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Long id;
+    private final String email;
+    private final UserType userType;
+
+    public CustomUserDetails(User user) {
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.userType = user.getUserType();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(() -> userType.name()); // ROLE_STUDENT, ROLE_COMPANY 같은 문자열
+    }
+
+    @Override
+    public String getUsername() {
+        return email;  // 로그인 시 아이디로 사용할 값
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // JWT 기반 인증이므로 null 반환
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+}


### PR DESCRIPTION
### 학생 프로필 관련 기능 API 구현
1. 학생 프로필 전체 조회
2. 학생 프로필 수정 (별명, 성별, 프로필 이미지)
3. 포트폴리오 추가/삭제
4. 태그 추가/수정/삭제

### 추후 수정 및 개선안
- 학생 프로필 수정
  - 프로필 이미지를 단일로 빼서 AWS S3 연동 후 프로필 이미지 추가/변경/삭제 구현.