### PR TITLE
refactor: 학생 태그 API 리팩터 및 응답 방식 변경

### DIFF
--- a/Idam/src/main/java/com/team7/Idam/domain/user/controller/AuthController.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/controller/AuthController.java
@@ -28,14 +28,14 @@ public class AuthController {
     @PostMapping("/api/signup/student")
     public ResponseEntity<ApiResponse> signupStudent(@Valid @RequestBody StudentSignupRequestDto request) {
         authService.signupStudent(request);
-        return ResponseEntity.ok(new ApiResponse("학생 회원가입이 완료되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success("학생 회원가입이 완료되었습니다."));
     }
 
     // 기업 회원가입
     @PostMapping("/api/signup/company")
     public ResponseEntity<ApiResponse> signupCompany(@Valid @RequestBody CompanySignupRequestDto request) {
         authService.signupCompany(request);
-        return ResponseEntity.ok(new ApiResponse("기업 회원가입이 완료되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success("기업 회원가입이 완료되었습니다."));
     }
 
     // 로그인
@@ -63,7 +63,7 @@ public class AuthController {
         expiredCookie.setMaxAge(0); // 쿠키 즉시 만료
         response.addCookie(expiredCookie);
 
-        return ResponseEntity.ok(new ApiResponse("로그아웃이 완료되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success("로그아웃이 완료되었습니다."));
     }
 
     // Refresh Token을 쿠키에 저장 (로그인, 재발급 시 사용)

--- a/Idam/src/main/java/com/team7/Idam/domain/user/controller/StudentProfileController.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/controller/StudentProfileController.java
@@ -4,13 +4,13 @@ import com.team7.Idam.domain.user.dto.profile.PortfolioRequestDto;
 import com.team7.Idam.domain.user.dto.profile.StudentProfileResponseDto;
 import com.team7.Idam.domain.user.dto.profile.StudentProfileUpdateRequestDto;
 import com.team7.Idam.domain.user.service.StudentProfileService;
+import com.team7.Idam.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/students")
@@ -21,63 +21,51 @@ public class StudentProfileController {
 
     // 프로필 전체 조회
     @GetMapping("/{studentId}/profile")
-    public StudentProfileResponseDto getStudentProfile(@PathVariable Long studentId) {
-        return studentService.getStudentProfile(studentId);
+    public ResponseEntity<ApiResponse<StudentProfileResponseDto>> getStudentProfile(@PathVariable Long studentId) {
+        StudentProfileResponseDto profile = studentService.getStudentProfile(studentId);
+        return ResponseEntity.ok(ApiResponse.success("프로필 조회 성공", profile));
     }
 
     // 프로필 정보 수정
     @PatchMapping("/{studentId}/profile")
-    public ResponseEntity<String> updateStudentProfile(@PathVariable Long studentId, @RequestBody StudentProfileUpdateRequestDto request) {
+    public ResponseEntity<ApiResponse<Void>> updateStudentProfile(@PathVariable Long studentId, @RequestBody StudentProfileUpdateRequestDto request) {
         studentService.updateStudentProfile(studentId, request);
-        return ResponseEntity.ok().body("프로필이 수정되었습니다.");
+        return ResponseEntity.ok(ApiResponse.success("프로필이 수정되었습니다."));
     }
 
     // 프로필 이미지 추가/수정
     @PutMapping("/{studentId}/profile/image")
-    public ResponseEntity<String> updateProfileImage(@PathVariable Long studentId, @RequestPart("profileImage") MultipartFile file) {
+    public ResponseEntity<ApiResponse<Void>> updateProfileImage(@PathVariable Long studentId, @RequestPart("profileImage") MultipartFile file) {
         studentService.updateProfileImage(studentId, file);
-        return ResponseEntity.ok().body("프로필 이미지가 수정되었습니다.");
+        return ResponseEntity.ok(ApiResponse.success("프로필 이미지가 수정되었습니다."));
     }
 
     // 프로필 이미지 삭제
     @DeleteMapping("/{studentId}/profile/image")
-    public ResponseEntity<String> deleteProfileImage(@PathVariable Long studentId) {
+    public ResponseEntity<ApiResponse<Void>> deleteProfileImage(@PathVariable Long studentId) {
         studentService.deleteProfileImage(studentId);
-        return ResponseEntity.ok().body("프로필 이미지가 삭제되었습니다.");
+        return ResponseEntity.ok(ApiResponse.success("프로필 이미지가 삭제되었습니다."));
     }
 
     // 포트폴리오 추가
     @PostMapping("/{studentId}/portfolios")
-    public ResponseEntity<String> addPortfolio(@PathVariable Long studentId, @RequestBody PortfolioRequestDto request) {
+    public ResponseEntity<ApiResponse<Void>> addPortfolio(@PathVariable Long studentId, @RequestBody PortfolioRequestDto request) {
         studentService.addPortfolio(studentId, request);
-        return ResponseEntity.ok().body("포트폴리오가 추가되었습니다.");
+        return ResponseEntity.ok(ApiResponse.success("포트폴리오가 추가되었습니다."));
     }
 
     // 포트폴리오 삭제
     @DeleteMapping("/{studentId}/portfolios/{portfolioId}")
-    public ResponseEntity<String> deletePortfolio(@PathVariable Long studentId, @PathVariable Long portfolioId) {
+    public ResponseEntity<ApiResponse<Void>> deletePortfolio(@PathVariable Long studentId, @PathVariable Long portfolioId) {
         studentService.deletePortfolio(studentId, portfolioId);
-        return ResponseEntity.ok().body("포트폴리오가 삭제되었습니다.");
+        return ResponseEntity.ok(ApiResponse.success("포트폴리오가 삭제되었습니다."));
     }
 
-    // 태그 추가
-    @PostMapping("/{studentId}/tags/{tagId}")
-    public ResponseEntity<String> addStudentTag(@PathVariable Long studentId, @PathVariable Long tagId) {
-        studentService.addStudentTag(studentId, tagId);
-        return ResponseEntity.ok().body("태그가 추가되었습니다.");
+    // 태그 추가/수정
+    @PutMapping("/{studentId}/categories/{categoryId}/tags")
+    public ResponseEntity<ApiResponse<Void>> updateStudentTags(@PathVariable Long studentId, @PathVariable Long categoryId, @RequestBody List<String> tagNames) {
+        studentService.updateStudentTagsByName(studentId, categoryId, tagNames);
+        return ResponseEntity.ok(ApiResponse.success("태그가 수정되었습니다."));
     }
 
-    // 태그 수정
-    @PutMapping("/{studentId}/tags")
-    public ResponseEntity<String> updateStudentTags(@PathVariable Long studentId, @RequestBody List<Long> tagIds) {
-        studentService.updateStudentTags(studentId, tagIds);
-        return ResponseEntity.ok().body("태그가 수정되었습니다.");
-    }
-
-    // 태그 삭제
-    @DeleteMapping("/{studentId}/tags/{tagId}")
-    public ResponseEntity<String> removeStudentTag(@PathVariable Long studentId, @PathVariable Long tagId) {
-        studentService.removeStudentTag(studentId, tagId);
-        return ResponseEntity.ok().body("태그가 삭제되었습니다.");
-    }
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/entity/Student.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/entity/Student.java
@@ -4,8 +4,8 @@ import com.team7.Idam.domain.user.entity.enums.Gender;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "student")
@@ -56,5 +56,11 @@ public class Student {
             joinColumns = @JoinColumn(name = "user_id"),
             inverseJoinColumns = @JoinColumn(name = "tag_id")
     )
-    private List<TagOption> tags = new ArrayList<>();
+    private Set<TagOption> tags = new HashSet<>();
+
+    public void setTags(Set<TagOption> tags) {
+        this.tags.clear();        // 기존 태그 초기화
+        this.tags.addAll(tags);   // 새 태그 추가
+    }
+
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/entity/TagCategory.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/entity/TagCategory.java
@@ -1,5 +1,6 @@
 package com.team7.Idam.domain.user.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -15,7 +16,8 @@ public class TagCategory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long categoryId;
+    @Column(name = "category_id")
+    private Long id;
 
     @Column(nullable = false, length = 100)
     private String categoryName;

--- a/Idam/src/main/java/com/team7/Idam/domain/user/repository/TagOptionRepository.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/repository/TagOptionRepository.java
@@ -4,6 +4,8 @@ import com.team7.Idam.domain.user.entity.TagOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TagOptionRepository extends JpaRepository<TagOption, Long> {
-}
+    List<TagOption> findAllByTagNameInAndCategoryId(List<String> tagNames, Long categoryId);}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/service/StudentProfileService.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/service/StudentProfileService.java
@@ -10,6 +10,7 @@ import com.team7.Idam.domain.user.repository.PortfolioRepository;
 import com.team7.Idam.domain.user.repository.StudentRepository;
 import com.team7.Idam.domain.user.repository.TagOptionRepository;
 import com.team7.Idam.jwt.CustomUserDetails;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
@@ -17,7 +18,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -51,6 +54,7 @@ public class StudentProfileService {
     /*
         학생 프로필 정보 수정
      */
+    @Transactional
     public void updateStudentProfile(Long studentId, StudentProfileUpdateRequestDto request) {
         Student student = studentRepository.findById(studentId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 학생을 찾을 수 없습니다."));
@@ -114,6 +118,7 @@ public class StudentProfileService {
     /*
         포트폴리오 추가
      */
+    @Transactional
     public void addPortfolio(Long studentId, PortfolioRequestDto request) {
         Student student = studentRepository.findById(studentId)
                 .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다."));
@@ -134,6 +139,7 @@ public class StudentProfileService {
     /*
         포트폴리오 삭제
      */
+    @Transactional
     public void deletePortfolio(Long studentId, Long portfolioId) {
         Portfolio portfolio = portfolioRepository.findById(portfolioId)
                 .orElseThrow(() -> new IllegalArgumentException("포트폴리오를 찾을 수 없습니다."));
@@ -146,51 +152,21 @@ public class StudentProfileService {
     }
 
     /*
-        태그 추가
+        태그 추가/수정
      */
-    public void addStudentTag(Long studentId, Long tagId) {
+    @Transactional
+    public void updateStudentTagsByName(Long studentId, Long categoryId, List<String> tagNames) {
         Student student = studentRepository.findById(studentId)
                 .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다."));
 
-        TagOption tag = tagOptionRepository.findById(tagId)
-                .orElseThrow(() -> new IllegalArgumentException("태그를 찾을 수 없습니다."));
+        // 카테고리 내에서만 태그 찾기
+        List<TagOption> tags = tagOptionRepository.findAllByTagNameInAndCategoryId(tagNames, categoryId);
 
-        if (student.getTags().contains(tag)) {
-            throw new IllegalArgumentException("이미 추가된 태그입니다.");
+        if (tags.size() != tagNames.size()) {
+            throw new IllegalArgumentException("해당 카테고리에서 일치하지 않는 태그명이 존재합니다.");
         }
 
-        student.getTags().add(tag);
-        studentRepository.save(student);
-    }
-
-    /*
-        태그 수정
-     */
-    public void updateStudentTags(Long studentId, List<Long> tagIds) {
-        Student student = studentRepository.findById(studentId)
-                .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다."));
-
-        List<TagOption> newTags = tagOptionRepository.findAllById(tagIds);
-
-        student.setTags(newTags);
-        studentRepository.save(student);
-    }
-
-    /*
-        태그 삭제
-     */
-    public void removeStudentTag(Long studentId, Long tagId) {
-        Student student = studentRepository.findById(studentId)
-                .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다."));
-
-        TagOption tag = tagOptionRepository.findById(tagId)
-                .orElseThrow(() -> new IllegalArgumentException("태그를 찾을 수 없습니다."));
-
-        if (!student.getTags().contains(tag)) {
-            throw new IllegalArgumentException("학생에게 해당 태그가 존재하지 않습니다.");
-        }
-
-        student.getTags().remove(tag);
+        student.setTags(new HashSet<>(tags));
         studentRepository.save(student);
     }
 }

--- a/Idam/src/main/java/com/team7/Idam/global/dto/ApiResponse.java
+++ b/Idam/src/main/java/com/team7/Idam/global/dto/ApiResponse.java
@@ -1,3 +1,29 @@
 package com.team7.Idam.global.dto;
 
-public record ApiResponse(String message) {}
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 값 필드는 JSON에서 제외
+public class ApiResponse<T> {
+    private boolean success;
+    private String message;
+    private T data;
+
+    // 성공 응답 (데이터 있음)
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data);
+    }
+
+    // 성공 응답 (데이터 없음)
+    public static <T> ApiResponse<T> success(String message) {
+        return new ApiResponse<>(true, message, null);
+    }
+
+    // 실패 응답
+    public static <T> ApiResponse<T> failure(String message) {
+        return new ApiResponse<>(false, message, null);
+    }
+}


### PR DESCRIPTION
### 변경 사항
1. 기존 태그 추가/수정/삭제API를 -> [PUT] 태그 추가/수정 단일 API로 통합.
2. 프론트 응답을 위한 ApiResponse 클래스 및 StudentProfileController 응답 방식 변경.
3. 태그 API의 EndPoint에 카테고리를 상위로 두어, 카테고리 별 태그 선택만 가능하도록 함.