### PR TITLE
refactor: 포트폴리오 API 수정

### DIFF
--- a/Idam/src/main/java/com/team7/Idam/domain/user/controller/StudentProfileController.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/controller/StudentProfileController.java
@@ -1,6 +1,5 @@
 package com.team7.Idam.domain.user.controller;
 
-import com.team7.Idam.domain.user.dto.profile.PortfolioRequestDto;
 import com.team7.Idam.domain.user.dto.profile.StudentProfileResponseDto;
 import com.team7.Idam.domain.user.dto.profile.StudentProfileUpdateRequestDto;
 import com.team7.Idam.domain.user.service.StudentProfileService;
@@ -49,9 +48,13 @@ public class StudentProfileController {
 
     // 포트폴리오 추가
     @PostMapping("/{studentId}/portfolios")
-    public ResponseEntity<ApiResponse<Void>> addPortfolio(@PathVariable Long studentId, @RequestBody PortfolioRequestDto request) {
-        studentService.addPortfolio(studentId, request);
-        return ResponseEntity.ok(ApiResponse.success("포트폴리오가 추가되었습니다."));
+    public ResponseEntity<ApiResponse<Void>> addPortfolio(
+            @PathVariable Long studentId,
+            @RequestPart(required = false) MultipartFile portfolioFile,
+            @RequestPart(required = false) String portfolioUrl) {
+
+        studentService.addPortfolio(studentId, portfolioFile, portfolioUrl);
+        return ResponseEntity.ok(ApiResponse.success("포트폴리오가 등록되었습니다."));
     }
 
     // 포트폴리오 삭제

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/PortfolioRequestDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/PortfolioRequestDto.java
@@ -1,8 +1,0 @@
-package com.team7.Idam.domain.user.dto.profile;
-
-import lombok.Data;
-
-@Data
-public class PortfolioRequestDto {
-    private String portfolio;
-}


### PR DESCRIPTION
### 주요 구현 사항
1. 기존 string으로 받던 요청을, string과 file 두 형식으로 받을 수 있도록 함.
2. file 형식 포트폴리오 > AWS S3 연동 완료, DB에 S3 주소 들어감.
3. file과 string 동시에 업로드 -> "불가능한 접근입니다." 예외처리