### PR TITLE
feat: 카테고리 별 태그 조회 API 구현

### DIFF
--- a/Idam/src/main/java/com/team7/Idam/domain/user/controller/TagController.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/controller/TagController.java
@@ -1,0 +1,33 @@
+package com.team7.Idam.domain.user.controller;
+
+import com.team7.Idam.domain.user.dto.Tag.TagOptionResponseDto;
+import com.team7.Idam.domain.user.entity.TagOption;
+import com.team7.Idam.domain.user.repository.TagOptionRepository;
+import com.team7.Idam.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/categories")
+@RequiredArgsConstructor
+public class TagController {
+
+    private final TagOptionRepository tagOptionRepository;
+
+    // 카테고리별 태그 조회
+    @GetMapping("/{categoryId}/tags")
+    public ResponseEntity<ApiResponse<List<TagOptionResponseDto>>> getTagsByCategory(@PathVariable Long categoryId) {
+        List<TagOption> tags = tagOptionRepository.findAllByCategoryId(categoryId);
+        List<TagOptionResponseDto> response = tags.stream()
+                .map(TagOptionResponseDto::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success("태그 조회 성공", response));
+    }
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/Tag/TagOptionResponseDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/Tag/TagOptionResponseDto.java
@@ -1,0 +1,9 @@
+package com.team7.Idam.domain.user.dto.Tag;
+
+import com.team7.Idam.domain.user.entity.TagOption;
+
+public record TagOptionResponseDto(Long id, String tagName) {
+    public static TagOptionResponseDto from(TagOption tag) {
+        return new TagOptionResponseDto(tag.getTagId(), tag.getTagName());
+    }
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/repository/TagOptionRepository.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/repository/TagOptionRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 @Repository
 public interface TagOptionRepository extends JpaRepository<TagOption, Long> {
-    List<TagOption> findAllByTagNameInAndCategoryId(List<String> tagNames, Long categoryId);}
+    List<TagOption> findAllByTagNameInAndCategoryId(List<String> tagNames, Long categoryId);
+    List<TagOption> findAllByCategoryId(Long categoryId);
+}


### PR DESCRIPTION
### 구현 사항
카테고리 조회 시, 해당 카테고리 하위의 태그들을 반환.

<img src="https://github.com/user-attachments/assets/7bb703f1-ebb3-4b28-89a3-d832200d6e67" width="500" />