### PR TITLE
feat: 학생 기업태그 매칭 API 구현 및 일부 코드 리팩터링

### DIFF
--- a/Idam/src/main/java/com/team7/Idam/config/SecurityConfig.java
+++ b/Idam/src/main/java/com/team7/Idam/config/SecurityConfig.java
@@ -46,8 +46,13 @@ public class SecurityConfig {
         return http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/signup/**", "/api/login", "/api/ai-tag").permitAll()
-                        .requestMatchers("/api/refresh", "/api/logout").permitAll()
+                        .requestMatchers(
+                                "/api/signup/**",
+                                "/api/login",
+                                "/api/refresh",
+                                "/api/ai-tag",
+                                "/api/categories/**"
+                        ).permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/**").hasAnyRole("USER", "ADMIN")
                         .anyRequest().authenticated()

--- a/Idam/src/main/java/com/team7/Idam/config/TagDataInitializer.java
+++ b/Idam/src/main/java/com/team7/Idam/config/TagDataInitializer.java
@@ -2,124 +2,50 @@ package com.team7.Idam.config;
 
 import com.team7.Idam.domain.user.entity.TagCategory;
 import com.team7.Idam.domain.user.entity.TagOption;
-import com.team7.Idam.domain.user.entity.Student;
 import com.team7.Idam.domain.user.repository.TagCategoryRepository;
 import com.team7.Idam.domain.user.repository.TagOptionRepository;
-import com.team7.Idam.domain.user.repository.StudentRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
+@Order(1) // 유저 초기화 전에 실행되도록
 @RequiredArgsConstructor
 @Transactional
 public class TagDataInitializer implements CommandLineRunner {
 
     private final TagCategoryRepository tagCategoryRepository;
     private final TagOptionRepository tagOptionRepository;
-    private final StudentRepository studentRepository;
 
     @Override
     public void run(String... args) {
-        // 더미데이터 중복 삽입 방지
         if (tagCategoryRepository.count() > 0 || tagOptionRepository.count() > 0) {
-            System.out.println("TagInitializer: 이미 데이터가 존재하여 초기화를 건너뜁니다.");
+            System.out.println("태그 데이터가 이미 존재하여 초기화를 건너뜁니다.");
             return;
         }
 
         // 1. 카테고리 생성
-        TagCategory itCategory = new TagCategory();
-        itCategory.setCategoryName("IT·프로그래밍");
-        tagCategoryRepository.save(itCategory);
-
-        TagCategory design = new TagCategory();
-        design.setCategoryName("디자인");
-        tagCategoryRepository.save(design);
-
-        TagCategory marketing = new TagCategory();
-        marketing.setCategoryName("마케팅");
-        tagCategoryRepository.save(marketing);
+        TagCategory it = tagCategoryRepository.save(new TagCategory("IT·프로그래밍"));
+        TagCategory design = tagCategoryRepository.save(new TagCategory("디자인"));
+        TagCategory marketing = tagCategoryRepository.save(new TagCategory("마케팅"));
 
         // 2. 태그 생성
+        tagOptionRepository.save(new TagOption("Java", it));
+        tagOptionRepository.save(new TagOption("Spring", it));
+        tagOptionRepository.save(new TagOption("React", it));
+        tagOptionRepository.save(new TagOption("Typescript", it));
+        tagOptionRepository.save(new TagOption("SQL", it));
 
-        // itCategory Tags
-        TagOption javaTag = new TagOption();
-        javaTag.setTagName("Java");
-        javaTag.setCategory(itCategory);
-        tagOptionRepository.save(javaTag);
+        tagOptionRepository.save(new TagOption("Adobe Photoshop", design));
+        tagOptionRepository.save(new TagOption("Adobe Illustrator", design));
+        tagOptionRepository.save(new TagOption("Figma", design));
 
-        TagOption springTag = new TagOption();
-        springTag.setTagName("Spring");
-        springTag.setCategory(itCategory);
-        tagOptionRepository.save(springTag);
+        tagOptionRepository.save(new TagOption("ShoppingMall Operation", marketing));
+        tagOptionRepository.save(new TagOption("SNS Management", marketing));
+        tagOptionRepository.save(new TagOption("CPA Marketing", marketing));
 
-        TagOption reactTag = new TagOption();
-        reactTag.setTagName("React");
-        reactTag.setCategory(itCategory);
-        tagOptionRepository.save(reactTag);
-
-        TagOption typescriptTag = new TagOption();
-        typescriptTag.setTagName("Typescript");
-        typescriptTag.setCategory(itCategory);
-        tagOptionRepository.save(typescriptTag);
-
-        TagOption sqlTag = new TagOption();
-        sqlTag.setTagName("SQL");
-        sqlTag.setCategory(itCategory);
-        tagOptionRepository.save(sqlTag);
-
-        // design Tags
-        TagOption adobePhotoshopTag = new TagOption();
-        adobePhotoshopTag.setTagName("Adobe Photoshop");
-        adobePhotoshopTag.setCategory(design);
-        tagOptionRepository.save(adobePhotoshopTag);
-
-        TagOption adobeIllustratorTag = new TagOption();
-        adobeIllustratorTag.setTagName("Adobe Illustrator");
-        adobeIllustratorTag.setCategory(design);
-        tagOptionRepository.save(adobeIllustratorTag);
-
-        TagOption figmaTag = new TagOption();
-        figmaTag.setTagName("Figma");
-        figmaTag.setCategory(design);
-        tagOptionRepository.save(figmaTag);
-
-        // marketing Tags
-        TagOption shoppingMallOperationTag = new TagOption();
-        shoppingMallOperationTag.setTagName("ShoppingMall Operation");
-        shoppingMallOperationTag.setCategory(marketing);
-        tagOptionRepository.save(shoppingMallOperationTag);
-
-        TagOption SNSManagementTag = new TagOption();
-        SNSManagementTag.setTagName("SNS Management");
-        SNSManagementTag.setCategory(marketing);
-        tagOptionRepository.save(SNSManagementTag);
-
-        TagOption CPAMarketingTag = new TagOption();
-        CPAMarketingTag.setTagName("CPA Marketing");
-        CPAMarketingTag.setCategory(marketing);
-        tagOptionRepository.save(CPAMarketingTag);
-
-        // 3. 테스트 학생에 태그 연결
-        Student student1 = studentRepository.findById(1L).orElse(null);
-        if (student1 != null) {
-            student1.getTags().addAll(List.of(javaTag, springTag, sqlTag));
-            studentRepository.save(student1);
-        }
-        Student student2 = studentRepository.findById(2L).orElse(null);
-        if (student2 != null) {
-            student2.getTags().addAll(List.of(adobePhotoshopTag, adobeIllustratorTag));
-            studentRepository.save(student2);
-        }
-        Student student3 = studentRepository.findById(3L).orElse(null);
-        if (student3 != null) {
-            student3.getTags().addAll(List.of(SNSManagementTag, CPAMarketingTag));
-            studentRepository.save(student3);
-        }
-
-        System.out.println("TagInitializer: 더미 데이터 초기화 완료!");
+        System.out.println("태그 카테고리 및 옵션 초기화 완료.");
     }
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/chat/entity/ChatMessage.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/chat/entity/ChatMessage.java
@@ -36,6 +36,7 @@ public class ChatMessage {
     private LocalDateTime sentAt;
 
     @Column(name = "is_read", nullable = false)
+    @Builder.Default
     private boolean isRead = false;
 
     @PrePersist

--- a/Idam/src/main/java/com/team7/Idam/domain/chat/entity/ChatRoom.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/chat/entity/ChatRoom.java
@@ -40,10 +40,12 @@ public class ChatRoom {
 
     // 삭제 여부 (soft delete)
     @Column(name = "is_deleted_by_company", nullable = false)
+    @Builder.Default
     private boolean isDeletedByCompany = false;
 
     // 삭제 여부 (soft delete)
     @Column(name = "is_deleted_by_student", nullable = false)
+    @Builder.Default
     private boolean isDeletedByStudent = false;
 
     @PrePersist

--- a/Idam/src/main/java/com/team7/Idam/domain/task/client/AiTagClient.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/task/client/AiTagClient.java
@@ -18,7 +18,7 @@ public class AiTagClient {
 
     public AiTagClient() {
         this.webClient = WebClient.builder()
-                .baseUrl("https://c8fc-117-16-195-75.ngrok-free.app") // 정확한 ngrok 주소
+                .baseUrl("https://3573-117-16-195-75.ngrok-free.app") // 정확한 ngrok 주소
                 .build();
     }
 

--- a/Idam/src/main/java/com/team7/Idam/domain/user/controller/MatchingController.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/controller/MatchingController.java
@@ -1,0 +1,27 @@
+package com.team7.Idam.domain.user.controller;
+
+import com.team7.Idam.domain.user.dto.matching.RecommendRequestDto;
+import com.team7.Idam.domain.user.dto.matching.ScoredStudentResponseDto;
+import com.team7.Idam.domain.user.service.MatchingService;
+import com.team7.Idam.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class MatchingController {
+
+    private final MatchingService matchingService;
+
+    @PostMapping("/api/matching")
+    public ResponseEntity<ApiResponse<List<ScoredStudentResponseDto>>> recommend(@RequestBody RecommendRequestDto request) {
+        List<ScoredStudentResponseDto> recommended = matchingService.recommendStudentsByCategory(request);
+        ApiResponse<List<ScoredStudentResponseDto>> response = ApiResponse.success("매칭 완료", recommended);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/controller/StudentProfileController.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/controller/StudentProfileController.java
@@ -2,14 +2,13 @@ package com.team7.Idam.domain.user.controller;
 
 import com.team7.Idam.domain.user.dto.profile.StudentProfileResponseDto;
 import com.team7.Idam.domain.user.dto.profile.StudentProfileUpdateRequestDto;
+import com.team7.Idam.domain.user.dto.profile.UpdateTagsRequestDto;
 import com.team7.Idam.domain.user.service.StudentProfileService;
 import com.team7.Idam.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/students")
@@ -65,10 +64,15 @@ public class StudentProfileController {
     }
 
     // 태그 추가/수정
-    @PutMapping("/{studentId}/categories/{categoryId}/tags")
-    public ResponseEntity<ApiResponse<Void>> updateStudentTags(@PathVariable Long studentId, @PathVariable Long categoryId, @RequestBody List<String> tagNames) {
-        studentService.updateStudentTagsByName(studentId, categoryId, tagNames);
+    @PutMapping("/{userId}/categories/{categoryId}/tags")
+    public ResponseEntity<ApiResponse<Void>> updateStudentTags(
+            @PathVariable Long userId,
+            @PathVariable Long categoryId,
+            @RequestBody UpdateTagsRequestDto request
+    ) {
+        studentService.updateStudentTagsByName(userId, categoryId, request);
         return ResponseEntity.ok(ApiResponse.success("태그가 수정되었습니다."));
     }
+
 
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/login/LogoutRequestDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/login/LogoutRequestDto.java
@@ -1,0 +1,10 @@
+package com.team7.Idam.domain.user.dto.login;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LogoutRequestDto {
+    private String deviceId;
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/matching/RecommendRequestDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/matching/RecommendRequestDto.java
@@ -1,0 +1,11 @@
+package com.team7.Idam.domain.user.dto.matching;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RecommendRequestDto {
+    private Long categoryId; // ai 요청 -> 도메인
+    private List<String> tags; // ai 요청 -> 기업 태그
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/matching/ScoredStudentResponseDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/matching/ScoredStudentResponseDto.java
@@ -1,0 +1,14 @@
+package com.team7.Idam.domain.user.dto.matching;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ScoredStudentResponseDto {
+    private Long userId;
+    private String name;
+    private int score;
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/StudentProfileResponseDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/StudentProfileResponseDto.java
@@ -16,4 +16,5 @@ public class StudentProfileResponseDto {
     private String profileImage;
     private String email;
     private String phone;
+    private Long categoryId;
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/UpdateTagsRequestDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/UpdateTagsRequestDto.java
@@ -1,0 +1,10 @@
+package com.team7.Idam.domain.user.dto.profile;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UpdateTagsRequestDto {
+    private List<String> tags;
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/signup/StudentSignupRequestDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/signup/StudentSignupRequestDto.java
@@ -50,4 +50,8 @@ public class StudentSignupRequestDto {
 
     @Size(max = 255)
     private String profileImage;
+
+    @NotBlank
+    @Size(max = 20)
+    private String categoryName;
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/entity/Student.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/entity/Student.java
@@ -19,11 +19,16 @@ public class Student {
     @Id
     private Long id;
 
-    /* User의 ID를 FK + PK로 삼는 종속 엔티티 */
+    /* <User> id를 FK + PK로 삼는 종속 엔티티 */
     @OneToOne
-    @MapsId
-    @JoinColumn(name = "id")  // FK이자 PK
+    @MapsId // PK
+    @JoinColumn(name = "id")  // FK (User)
     private User user;
+
+    /* <TagCategory> category_id를 FK로 삼는 종속 엔티티 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id") // FK (TagCategory)
+    private TagCategory category;
 
     @Column(nullable = false, length = 50)
     private String name;
@@ -50,14 +55,22 @@ public class Student {
     @Column(nullable = true, length = 10)
     private Gender gender;
 
+    /*
+        student_tag 테이블 생성 / <student>와 <student_tag> 다대다 관계
+        -> user_id (FK to student.id)
+        -> tag_id  (FK to tag_option.id)
+     */
     @ManyToMany
     @JoinTable(
             name = "student_tag",
             joinColumns = @JoinColumn(name = "user_id"),
             inverseJoinColumns = @JoinColumn(name = "tag_id")
     )
+    // Student가 가지고 있는 TagOption 목록 (Set으로 중복 허용 X)
+    @Builder.Default
     private Set<TagOption> tags = new HashSet<>();
 
+    // 태그 수정
     public void setTags(Set<TagOption> tags) {
         this.tags.clear();        // 기존 태그 초기화
         this.tags.addAll(tags);   // 새 태그 추가

--- a/Idam/src/main/java/com/team7/Idam/domain/user/entity/TagCategory.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/entity/TagCategory.java
@@ -1,6 +1,5 @@
 package com.team7.Idam.domain.user.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,9 +18,13 @@ public class TagCategory {
     @Column(name = "category_id")
     private Long id;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, unique = true, length = 100)
     private String categoryName;
 
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
     private List<TagOption> tagOptions = new ArrayList<>();
+
+    public TagCategory(String categoryName) {
+        this.categoryName = categoryName;
+    }
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/entity/TagOption.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/entity/TagOption.java
@@ -26,4 +26,9 @@ public class TagOption {
 
     @ManyToMany(mappedBy = "tags")
     private List<Student> students = new ArrayList<>();
+
+    public TagOption(String tagName, TagCategory category) {
+        this.tagName = tagName;
+        this.category = category;
+    }
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/entity/User.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/entity/User.java
@@ -27,6 +27,7 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "user_status", nullable = false, length = 20)
+    @Builder.Default
     private UserStatus userStatus = UserStatus.ACTIVE;  // 기본값은 ACTIVE
 
     @Column(length = 20, unique = true)

--- a/Idam/src/main/java/com/team7/Idam/domain/user/repository/PortfolioRepository.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/repository/PortfolioRepository.java
@@ -3,8 +3,6 @@ package com.team7.Idam.domain.user.repository;
 import com.team7.Idam.domain.user.entity.Portfolio;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
-    boolean existsByStudentIdAndPortfolio(Long studentId, String portfolio);
+    boolean existsByStudentIdAndPortfolio(Long userId, String portfolio);
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/repository/StudentRepository.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/repository/StudentRepository.java
@@ -3,9 +3,11 @@ package com.team7.Idam.domain.user.repository;
 import com.team7.Idam.domain.user.entity.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface StudentRepository extends JpaRepository<Student, Long> {
     boolean existsByNickname(String nickname); // 별명 중복 방지
     boolean existsBySchoolId(String schoolId); // 학번 중복 방지
+
+    List<Student> findAllByCategoryId(Long categoryId);
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/repository/TagCategoryRepository.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/repository/TagCategoryRepository.java
@@ -4,6 +4,9 @@ import com.team7.Idam.domain.user.entity.TagCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface TagCategoryRepository extends JpaRepository<TagCategory, Long> {
+    Optional<TagCategory> findByCategoryName(String categoryName);
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/repository/TagOptionRepository.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/repository/TagOptionRepository.java
@@ -1,5 +1,6 @@
 package com.team7.Idam.domain.user.repository;
 
+import com.team7.Idam.domain.user.entity.TagCategory;
 import com.team7.Idam.domain.user.entity.TagOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +11,6 @@ import java.util.List;
 public interface TagOptionRepository extends JpaRepository<TagOption, Long> {
     List<TagOption> findAllByTagNameInAndCategoryId(List<String> tagNames, Long categoryId);
     List<TagOption> findAllByCategoryId(Long categoryId);
+
+    List<TagOption> findAllByCategory(TagCategory itCategory);
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/service/AuthService.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/service/AuthService.java
@@ -7,6 +7,7 @@ import com.team7.Idam.domain.user.dto.login.LoginRequestDto;
 import com.team7.Idam.domain.user.entity.*;
 import com.team7.Idam.domain.user.entity.enums.UserType;
 import com.team7.Idam.domain.user.entity.enums.UserStatus;
+import com.team7.Idam.domain.user.repository.TagCategoryRepository;
 import com.team7.Idam.domain.user.repository.UserRepository;
 import com.team7.Idam.domain.user.repository.StudentRepository;
 import com.team7.Idam.domain.user.repository.CompanyRepository;
@@ -15,8 +16,6 @@ import com.team7.Idam.global.util.RefreshTokenStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.List;
 
@@ -27,6 +26,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final StudentRepository studentRepository;
     private final CompanyRepository companyRepository;
+    private final TagCategoryRepository tagCategoryRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenStore refreshTokenStore;
@@ -49,6 +49,10 @@ public class AuthService {
             throw new IllegalArgumentException("이미 등록된 학번입니다.");
         }
 
+        // 💡 카테고리 이름으로 TagCategory 조회
+        TagCategory category = tagCategoryRepository.findByCategoryName(request.getCategoryName())
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 분야가 존재하지 않습니다."));
+
         // User 생성
         User user = User.builder()
                 .email(request.getEmail())
@@ -69,6 +73,7 @@ public class AuthService {
                 .password(passwordEncoder.encode(request.getPassword()))
                 .gender(request.getGender())
                 .profileImage(request.getProfileImage())
+                .category(category)
                 .build();
         studentRepository.save(student);
     }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/service/MatchingService.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/service/MatchingService.java
@@ -1,0 +1,68 @@
+package com.team7.Idam.domain.user.service;
+
+import com.team7.Idam.domain.user.dto.matching.RecommendRequestDto;
+import com.team7.Idam.domain.user.dto.matching.ScoredStudentResponseDto;
+import com.team7.Idam.domain.user.entity.Student;
+import com.team7.Idam.domain.user.entity.TagOption;
+import com.team7.Idam.domain.user.entity.enums.UserType;
+import com.team7.Idam.domain.user.repository.StudentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.team7.Idam.global.util.SecurityUtil;
+
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class MatchingService {
+
+    private final StudentRepository studentRepository;
+
+    public void validateCompanyAccess() {
+        if (SecurityUtil.getCurrentUserType() != UserType.COMPANY) {
+            throw new AccessDeniedException("해당 기능은 기업 회원만 사용할 수 있습니다.");
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<ScoredStudentResponseDto> recommendStudentsByCategory(RecommendRequestDto request) {
+        validateCompanyAccess(); // 기업 타입만 실행 가능
+
+        Long categoryId = request.getCategoryId();
+        List<String> requestedTags = request.getTags();
+
+        // 해당 분야(categoryId)의 학생들 조회
+        List<Student> students = studentRepository.findAllByCategoryId(categoryId);
+
+        if (students.isEmpty()) {
+            throw new IllegalArgumentException("해당 분야에 등록된 학생이 존재하지 않습니다.");
+        }
+
+        // 태그 이름 Set으로 변환 (contains 성능 ↑)
+        Set<String> tagNameSet = new HashSet<>(requestedTags);
+
+        // 점수 계산 및 DTO 리스트 생성
+        List<ScoredStudentResponseDto> result = new ArrayList<>();
+
+        for (Student student : students) {
+            int score = (int) student.getTags().stream()
+                    .map(TagOption::getTagName)
+                    .filter(tagNameSet::contains)
+                    .count();
+
+            result.add(new ScoredStudentResponseDto(student.getId(), student.getName(), score));
+        }
+
+        // 점수 기준 내림차순 정렬 후 상위 5명 반환
+        return result.stream()
+                .sorted((a, b) -> Integer.compare(b.getScore(), a.getScore()))
+                .limit(5)
+                .toList();
+    }
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/service/StudentProfileService.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/service/StudentProfileService.java
@@ -2,19 +2,19 @@ package com.team7.Idam.domain.user.service;
 
 import com.team7.Idam.domain.user.dto.profile.StudentProfileResponseDto;
 import com.team7.Idam.domain.user.dto.profile.StudentProfileUpdateRequestDto;
+import com.team7.Idam.domain.user.dto.profile.UpdateTagsRequestDto;
 import com.team7.Idam.domain.user.entity.Portfolio;
 import com.team7.Idam.domain.user.entity.Student;
 import com.team7.Idam.domain.user.entity.TagOption;
 import com.team7.Idam.domain.user.repository.PortfolioRepository;
 import com.team7.Idam.domain.user.repository.StudentRepository;
 import com.team7.Idam.domain.user.repository.TagOptionRepository;
-import com.team7.Idam.jwt.CustomUserDetails;
-import jakarta.transaction.Transactional;
+import com.team7.Idam.global.util.SecurityUtil;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.HashSet;
@@ -29,11 +29,21 @@ public class StudentProfileService {
     private final TagOptionRepository tagOptionRepository;
     private final FileUploadService fileUploadService;
 
+    // AccessToken 사용자 == 요청된 UserId 일치할 때만 로직 수행.
+    public void validateStudentAccess(Long requestedUserId) {
+        Long loginUserId = SecurityUtil.getCurrentUserId(); // JWT 기반 사용자 ID
+        if (!loginUserId.equals(requestedUserId)) {
+            throw new AccessDeniedException("자신의 정보에만 접근할 수 있습니다.");
+        }
+    }
+
     /*
         학생 프로필 전체 조회
      */
-    public StudentProfileResponseDto getStudentProfile(Long studentId) {
-        Student student = studentRepository.findById(studentId)
+    public StudentProfileResponseDto getStudentProfile(Long userId) {
+        validateStudentAccess(userId);
+
+        Student student = studentRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 학생을 찾을 수 없습니다."));
 
         return StudentProfileResponseDto.builder()
@@ -46,6 +56,7 @@ public class StudentProfileService {
                 .profileImage(student.getProfileImage())
                 .email(student.getUser().getEmail())
                 .phone(student.getUser().getPhone())
+                .categoryId(student.getCategory().getId())
                 .build();
     }
 
@@ -53,14 +64,11 @@ public class StudentProfileService {
         학생 프로필 정보 수정
      */
     @Transactional
-    public void updateStudentProfile(Long studentId, StudentProfileUpdateRequestDto request) {
-        Student student = studentRepository.findById(studentId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 학생을 찾을 수 없습니다."));
+    public void updateStudentProfile(Long userId, StudentProfileUpdateRequestDto request) {
+        validateStudentAccess(userId);
 
-        Long currentUserId = getCurrentUserId();  // JWT에서 추출
-        if (!student.getUser().getId().equals(currentUserId)) {
-            throw new AccessDeniedException("본인만 수정할 수 있습니다.");
-        }
+        Student student = studentRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 학생을 찾을 수 없습니다."));
 
         if (request.getNickname() != null) {
             student.setNickname(request.getNickname());
@@ -72,17 +80,13 @@ public class StudentProfileService {
         studentRepository.save(student);
     }
 
-    private Long getCurrentUserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        return userDetails.getId();
-    }
-
     /*
         프로필 이미지 업로드
      */
-    public void updateProfileImage(Long studentId, MultipartFile file) {
-        Student student = studentRepository.findById(studentId)
+    public void updateProfileImage(Long userId, MultipartFile file) {
+        validateStudentAccess(userId);
+
+        Student student = studentRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 학생을 찾을 수 없습니다."));
 
         if (student.getProfileImage() != null) { // 프로필 이미지 이미 존재 시
@@ -98,8 +102,10 @@ public class StudentProfileService {
     /*
         프로필 이미지 삭제
      */
-    public void deleteProfileImage(Long studentId) {
-        Student student = studentRepository.findById(studentId)
+    public void deleteProfileImage(Long userId) {
+        validateStudentAccess(userId);
+
+        Student student = studentRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 학생을 찾을 수 없습니다."));
 
         String imageUrl = student.getProfileImage();
@@ -117,7 +123,7 @@ public class StudentProfileService {
         포트폴리오 추가
      */
     @Transactional
-    public void addPortfolio(Long studentId, MultipartFile file, String url) {
+    public void addPortfolio(Long userId, MultipartFile file, String url) {
         // 둘 다 비어있을 때
         if (file == null && (url == null || url.isBlank())) {
             throw new IllegalArgumentException("파일 또는 URL 중 하나는 반드시 입력되어야 합니다.");
@@ -128,14 +134,14 @@ public class StudentProfileService {
             throw new IllegalArgumentException("불가능한 접근입니다.");
         }
 
-        Student student = studentRepository.findById(studentId)
+        Student student = studentRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다."));
 
         String portfolioValue = (file != null)
                 ? fileUploadService.upload(file)
                 : url;
 
-        boolean exists = portfolioRepository.existsByStudentIdAndPortfolio(studentId, portfolioValue);
+        boolean exists = portfolioRepository.existsByStudentIdAndPortfolio(userId, portfolioValue);
         if (exists) {
             throw new IllegalArgumentException("이미 동일한 포트폴리오가 등록되어 있습니다.");
         }
@@ -152,11 +158,11 @@ public class StudentProfileService {
         포트폴리오 삭제
      */
     @Transactional
-    public void deletePortfolio(Long studentId, Long portfolioId) {
+    public void deletePortfolio(Long userId, Long portfolioId) {
         Portfolio portfolio = portfolioRepository.findById(portfolioId)
                 .orElseThrow(() -> new IllegalArgumentException("포트폴리오를 찾을 수 없습니다."));
 
-        if (!portfolio.getStudent().getId().equals(studentId)) {
+        if (!portfolio.getStudent().getId().equals(userId)) {
             throw new SecurityException("본인만 삭제할 수 있습니다.");
         }
 
@@ -179,9 +185,13 @@ public class StudentProfileService {
         태그 추가/수정
      */
     @Transactional
-    public void updateStudentTagsByName(Long studentId, Long categoryId, List<String> tagNames) {
-        Student student = studentRepository.findById(studentId)
+    public void updateStudentTagsByName(Long userId, Long categoryId, UpdateTagsRequestDto request) {
+        validateStudentAccess(userId);
+
+        Student student = studentRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다."));
+
+        List<String> tagNames = request.getTags();
 
         // 카테고리 내에서만 태그 찾기
         List<TagOption> tags = tagOptionRepository.findAllByTagNameInAndCategoryId(tagNames, categoryId);

--- a/Idam/src/main/java/com/team7/Idam/global/util/RefreshTokenStore.java
+++ b/Idam/src/main/java/com/team7/Idam/global/util/RefreshTokenStore.java
@@ -28,9 +28,11 @@ public class RefreshTokenStore {
     }
 
     // 삭제
-    public void delete(Long userId, String deviceId) {
+    public boolean delete(Long userId, String deviceId) {
         String key = buildKey(userId, deviceId);
+        Boolean existed = redisTemplate.hasKey(key);
         redisTemplate.delete(key);
+        return Boolean.TRUE.equals(existed);
     }
 
     // key 생성

--- a/Idam/src/main/java/com/team7/Idam/global/util/SecurityUtil.java
+++ b/Idam/src/main/java/com/team7/Idam/global/util/SecurityUtil.java
@@ -1,0 +1,51 @@
+package com.team7.Idam.global.util;
+
+import com.team7.Idam.domain.user.entity.enums.UserType;
+import com.team7.Idam.jwt.CustomUserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/*
+    AccessToken에 담긴 사용자 정보를 기반으로, "현재 로그인한 사용자"의 정보를 알려주는 도구들
+ */
+public class SecurityUtil {
+
+    // 현재 로그인한 사용자의 User.id (DB PK)를 반환
+    public static Long getCurrentUserId() {
+        /*
+            Authentication 객체 == Spring Security의 현재 로그인 상태를 나타냄.
+            SecurityContextHolder == 현재 요청 스레드의 인증 정보를 저장하고 있는 보안 컨텍스트.
+         */
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 로그인하지 않은 요청 || 우리가 기대하는 CustomUserDetails 타입이 아님
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails)) {
+            throw new IllegalStateException("인증된 사용자가 존재하지 않습니다.");
+        }
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getId();
+    }
+
+    // 현재 로그인한 사용자의 UserType (STUDENT, COMPANY, ADMIN)을 반환
+    public static UserType getCurrentUserType() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails)) {
+            throw new IllegalStateException("인증된 사용자가 존재하지 않습니다.");
+        }
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getUserType();  // UserType.STUDENT / COMPANY / ADMIN 등
+    }
+
+    // 현재 로그인한 사용자의 전체 정보가 담긴 CustomUserDetails 객체 자체를 반환
+    // (여러 필드 동시 필요 시)
+    public static CustomUserDetails getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails)) {
+            throw new IllegalStateException("인증된 사용자가 존재하지 않습니다.");
+        }
+
+        return (CustomUserDetails) authentication.getPrincipal();
+    }
+}

--- a/Idam/src/main/java/com/team7/Idam/jwt/JwtAuthenticationFilter.java
+++ b/Idam/src/main/java/com/team7/Idam/jwt/JwtAuthenticationFilter.java
@@ -35,8 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         System.out.println("🔥 요청 URI: " + uri);
         System.out.println("🔥 들어온 Authorization 헤더: " + request.getHeader("Authorization"));
 
-        if (uri.startsWith("/api/refresh") || uri.startsWith("/api/logout") ||
-                uri.startsWith("/api/login") || uri.startsWith("/api/signup")) {
+        if (uri.startsWith("/api/refresh") || uri.startsWith("/api/login") || uri.startsWith("/api/signup")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/Idam/src/main/java/com/team7/Idam/jwt/JwtTokenProvider.java
+++ b/Idam/src/main/java/com/team7/Idam/jwt/JwtTokenProvider.java
@@ -59,6 +59,7 @@ public class JwtTokenProvider {
             parseClaims(token);
             return true;
         } catch (JwtException | IllegalArgumentException e) {
+            System.out.println("JWT 유효성 검증 실패: " + e.getClass().getSimpleName() + " - " + e.getMessage());
             return false;
         }
     }


### PR DESCRIPTION
## 구현 사항
### 1. 학생 - 기업 간 태그 매칭 API 구현
  - 카테고리(도메인) 및 태그들을 받으면, 일치하는 학생들에게 가점 +1.
  - 총합이 가장 높은 학생 5명 반환.

### 2. 로그아웃 API 리팩터링
  - userId 및 deviceId를 EndPoint에서 뺌.
    - userId : 현재 로그인 된 유저의 userId를 내부적으로 가져옴.
    - deviceId : EndPoint 노출이 아닌, JSON 데이터로 requestBody 요청.

### 3. 더미데이터 리팩터링
  - 생성 순서를 TagDataInitializer -> UserDataInitializer로 변경.
  - TagDataInitializer의 경우, 기존 카테고리 및 태그 데이터만 담아 우선 생성하는 것으로 변경.
  - UserDataInitializer에서 유저 데이터 생성 시, 기본 태그 데이터 또한 가지고 생성.

### 4. PUT 태그 추가/수정 API 리팩터링
  - list 형태의 requestBody 요청에서 JSON형태로 변경.

### 5. AccessToken 접근 방식 리팩터링
  - accessToken 사용자(로그인 한 유저)와 현재 요청 중인 유저(EndPoint 상)가 일치 시 접근할 수 있도록 변경.


