### PR TITLE
feat: 채팅방 프로젝트 명 생성 및 접근 권한 설정

### DIFF
--- a/Idam/src/main/java/com/team7/Idam/config/UserDataInitializer.java
+++ b/Idam/src/main/java/com/team7/Idam/config/UserDataInitializer.java
@@ -54,7 +54,6 @@ public class UserDataInitializer implements CommandLineRunner {
                             .major("정보통신공학과")
                             .schoolId("2023" + String.format("%05d", i))
                             .password("student1234")
-                            .profileImage("default-student.jpg")
                             .gender((i % 2 == 0) ? Gender.FEMALE : Gender.MALE)
                             .category(itCategory)
                             .build()
@@ -105,7 +104,6 @@ public class UserDataInitializer implements CommandLineRunner {
                             .companyName("기업사" + i)
                             .address("서울시 강남구 테헤란로 " + (10 + i))
                             .website("https://company" + i + ".example.com")
-                            .profileImage("default-company.jpg")
                             .build()
             );
         }

--- a/Idam/src/main/java/com/team7/Idam/domain/chat/controller/ChatController.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/chat/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.team7.Idam.domain.chat.controller;
 
 import com.team7.Idam.domain.chat.dto.ChatMessageResponseDto;
+import com.team7.Idam.domain.chat.dto.ChatRoomRequestDto;
 import com.team7.Idam.domain.chat.dto.ChatRoomResponseDto;
 import com.team7.Idam.domain.chat.dto.SendMessageRequestDto;
 import com.team7.Idam.domain.chat.service.ChatMessageService;
@@ -28,12 +29,13 @@ public class ChatController {
     @PostMapping("/room")
     public ResponseEntity<ChatRoomResponseDto> createRoom(
             @RequestParam Long targetUserId,
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody ChatRoomRequestDto request
     ) {
         User managedCompany = userService.getUserById(userDetails.getId());
         User managedStudent = userService.getUserById(targetUserId);
         System.out.println(">> 로그인한 유저 ID: " + managedCompany.getId());
-        return ResponseEntity.ok(chatRoomService.createRoom(managedCompany, managedStudent));
+        return ResponseEntity.ok(chatRoomService.createRoom(managedCompany, managedStudent, request));
     }
 
     // 채팅방 목록 조회 (기업)

--- a/Idam/src/main/java/com/team7/Idam/domain/chat/dto/ChatRoomRequestDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/chat/dto/ChatRoomRequestDto.java
@@ -1,0 +1,8 @@
+package com.team7.Idam.domain.chat.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChatRoomRequestDto {
+    private String projectTitle;
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/chat/dto/ChatRoomResponseDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/chat/dto/ChatRoomResponseDto.java
@@ -18,6 +18,7 @@ public class ChatRoomResponseDto {
     private String opponentProfileImage;
     private String lastMessage;
     private LocalDateTime lastMessageAt;
+    private String projectTitle;
 
     public static ChatRoomResponseDto from(ChatRoom room, User currentUser) {
         User opponent = room.getCompany().equals(currentUser)
@@ -43,6 +44,7 @@ public class ChatRoomResponseDto {
                 .opponentProfileImage(opponentProfileImage)
                 .lastMessage(room.getLastMessage())
                 .lastMessageAt(room.getLastMessageAt())
+                .projectTitle(room.getProjectTitle())
                 .build();
     }
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/chat/entity/ChatRoom.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/chat/entity/ChatRoom.java
@@ -66,4 +66,7 @@ public class ChatRoom {
     public void deleteByStudent() {
         this.isDeletedByStudent = true;
     }
+
+    @Column(name = "project_title", length = 100, nullable = false)
+    private String projectTitle;
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/chat/service/ChatRoomService.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/chat/service/ChatRoomService.java
@@ -1,16 +1,21 @@
 package com.team7.Idam.domain.chat.service;
 
+import com.team7.Idam.domain.chat.dto.ChatRoomRequestDto;
 import com.team7.Idam.domain.chat.dto.ChatRoomResponseDto;
 import com.team7.Idam.domain.chat.entity.ChatRoom;
 import com.team7.Idam.domain.chat.repository.ChatRoomRepository;
 import com.team7.Idam.domain.user.entity.User;
+import com.team7.Idam.domain.user.entity.enums.UserType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static com.team7.Idam.global.util.SecurityUtil.getCurrentUserType;
 
 @Service
 @RequiredArgsConstructor
@@ -18,11 +23,25 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
 
+    public static void validateCompanyAccess() {
+        if (getCurrentUserType() != UserType.COMPANY) {
+            throw new AccessDeniedException("해당 기능은 기업 회원만 사용할 수 있습니다.");
+        }
+    }
+
+    public static void validateStudentAccess() {
+        if (getCurrentUserType() != UserType.STUDENT) {
+            throw new AccessDeniedException("해당 기능은 학생 회원만 사용할 수 있습니다.");
+        }
+    }
+
     // 1. 새로운 채팅방 생성
-    public ChatRoomResponseDto createRoom(User company, User student) {
+    public ChatRoomResponseDto createRoom(User company, User student, ChatRoomRequestDto request) {
+        validateCompanyAccess(); // 기업 타입만 실행 가능
         ChatRoom chatRoom = ChatRoom.builder()
                 .company(company)
                 .student(student)
+                .projectTitle(request.getProjectTitle())
                 .build();
         ChatRoom savedRoom = chatRoomRepository.save(chatRoom);
         return ChatRoomResponseDto.from(savedRoom, company);
@@ -36,6 +55,7 @@ public class ChatRoomService {
 
     // 3. 기업의 채팅방 목록 조회 (DTO 반환)
     public List<ChatRoomResponseDto> getCompanyChatRooms(User company) {
+        validateCompanyAccess(); // 기업 타입만 실행 가능
         return chatRoomRepository.findByCompanyAndIsDeletedByCompanyFalse(company).stream()
                 .map(room -> ChatRoomResponseDto.from(room, company))
                 .collect(Collectors.toList());
@@ -43,6 +63,7 @@ public class ChatRoomService {
 
     // 4. 학생의 채팅방 목록 조회 (DTO 반환)
     public List<ChatRoomResponseDto> getStudentChatRooms(User student) {
+        validateStudentAccess(); // 학생 타입만 실행 가능
         return chatRoomRepository.findByStudentAndIsDeletedByStudentFalse(student).stream()
                 .map(room -> ChatRoomResponseDto.from(room, student))
                 .collect(Collectors.toList());
@@ -51,6 +72,7 @@ public class ChatRoomService {
     // 5. 기업이 채팅방 soft delete
     @Transactional
     public void deleteRoomByCompany(Long roomId, User company) {
+        validateCompanyAccess(); // 기업 타입만 실행 가능
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
         if (!room.getCompany().equals(company)) {
@@ -62,6 +84,7 @@ public class ChatRoomService {
     // 6. 학생이 채팅방 soft delete
     @Transactional
     public void deleteRoomByStudent(Long roomId, User student) {
+        validateStudentAccess(); // 학생 타입만 실행 가능
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
         if (!room.getStudent().equals(student)) {
@@ -72,6 +95,7 @@ public class ChatRoomService {
 
     // 7. 기업이 학생 닉네임으로 채팅방 검색 (DTO 반환)
     public List<ChatRoomResponseDto> searchRoomsByStudentNickname(User company, String keyword) {
+        validateCompanyAccess(); // 기업 타입만 실행 가능
         return chatRoomRepository.searchRoomsByStudentNickname(company, keyword).stream()
                 .map(room -> ChatRoomResponseDto.from(room, company))
                 .collect(Collectors.toList());
@@ -79,6 +103,7 @@ public class ChatRoomService {
 
     // 8. 학생이 기업 이름으로 채팅방 검색 (DTO 반환)
     public List<ChatRoomResponseDto> searchRoomsByCompanyName(User student, String keyword) {
+        validateStudentAccess(); // 학생 타입만 실행 가능
         return chatRoomRepository.searchRoomsByCompanyName(student, keyword).stream()
                 .map(room -> ChatRoomResponseDto.from(room, student))
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 주요 구현 사항
- 채팅방 생성 시 프로젝트 명 포함.
- 채팅방 목록 조회 시 프로젝트 명 응답으로 같이 반환.
- 학생/기업에 따라 접근 권한 설정.


## 추가 구현안
- 더미데이터 생성 시 프로필이미지 기본값 null로 설정.