### PR TITLE
feat: 기업 프로필 수정 API 구현 및 기업 소개란 추가

### DIFF
--- a/Idam/src/main/java/com/team7/Idam/config/UserDataInitializer.java
+++ b/Idam/src/main/java/com/team7/Idam/config/UserDataInitializer.java
@@ -108,6 +108,7 @@ public class UserDataInitializer implements CommandLineRunner {
                             .companyName("기업사" + i)
                             .address("서울시 강남구 테헤란로 " + (10 + i))
                             .website("https://company" + i + ".example.com")
+                            .companyDescription("기업 소개가 없습니다.")
                             .build()
             );
         }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/controller/CompanyProfileController.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/controller/CompanyProfileController.java
@@ -1,6 +1,7 @@
 package com.team7.Idam.domain.user.controller;
 
-import com.team7.Idam.domain.user.dto.profile.CompanyProfileResponseDto;
+import com.team7.Idam.domain.user.dto.profile.company.CompanyProfileResponseDto;
+import com.team7.Idam.domain.user.dto.profile.company.CompanyProfileUpdateRequestDto;
 import com.team7.Idam.domain.user.service.CompanyProfileService;
 import com.team7.Idam.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -35,4 +36,12 @@ public class CompanyProfileController {
         companyService.deleteProfileImage(userId);
         return ResponseEntity.ok(ApiResponse.success("프로필 이미지가 삭제되었습니다."));
     }
+
+    // 프로필 정보 수정
+    @PatchMapping("/{userId}/profile")
+    public ResponseEntity<ApiResponse<Void>> updateCompanyProfile(@PathVariable Long userId, @RequestBody CompanyProfileUpdateRequestDto request) {
+        companyService.updateCompanyProfile(userId, request);
+        return ResponseEntity.ok(ApiResponse.success("프로필이 수정되었습니다."));
+    }
+
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/controller/StudentProfileController.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/controller/StudentProfileController.java
@@ -1,9 +1,9 @@
 package com.team7.Idam.domain.user.controller;
 
-import com.team7.Idam.domain.user.dto.profile.StudentPreviewResponseDto;
-import com.team7.Idam.domain.user.dto.profile.StudentProfileResponseDto;
-import com.team7.Idam.domain.user.dto.profile.StudentProfileUpdateRequestDto;
-import com.team7.Idam.domain.user.dto.profile.UpdateTagsRequestDto;
+import com.team7.Idam.domain.user.dto.profile.student.StudentPreviewResponseDto;
+import com.team7.Idam.domain.user.dto.profile.student.StudentProfileResponseDto;
+import com.team7.Idam.domain.user.dto.profile.student.StudentProfileUpdateRequestDto;
+import com.team7.Idam.domain.user.dto.profile.student.UpdateTagsRequestDto;
 import com.team7.Idam.domain.user.service.StudentProfileService;
 import com.team7.Idam.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/company/CompanyProfileResponseDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/company/CompanyProfileResponseDto.java
@@ -1,4 +1,4 @@
-package com.team7.Idam.domain.user.dto.profile;
+package com.team7.Idam.domain.user.dto.profile.company;
 
 import lombok.Builder;
 import lombok.Data;
@@ -13,4 +13,5 @@ public class CompanyProfileResponseDto {
     private String profileImage;
     private String email;
     private String phone;
+    private String companyDescription;
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/company/CompanyProfileUpdateRequestDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/company/CompanyProfileUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package com.team7.Idam.domain.user.dto.profile.company;
+
+import lombok.Data;
+
+@Data
+public class CompanyProfileUpdateRequestDto {
+    private String companyDescription;
+    private String website;
+}

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/student/PortfolioResponseDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/student/PortfolioResponseDto.java
@@ -1,4 +1,4 @@
-package com.team7.Idam.domain.user.dto.profile;
+package com.team7.Idam.domain.user.dto.profile.student;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/student/StudentPreviewResponseDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/student/StudentPreviewResponseDto.java
@@ -1,4 +1,4 @@
-package com.team7.Idam.domain.user.dto.profile;
+package com.team7.Idam.domain.user.dto.profile.student;
 
 import com.team7.Idam.domain.user.entity.Student;
 import com.team7.Idam.domain.user.entity.TagOption;

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/student/StudentProfileResponseDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/student/StudentProfileResponseDto.java
@@ -1,4 +1,4 @@
-package com.team7.Idam.domain.user.dto.profile;
+package com.team7.Idam.domain.user.dto.profile.student;
 
 import com.team7.Idam.domain.user.entity.enums.Gender;
 import lombok.Builder;

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/student/StudentProfileUpdateRequestDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/student/StudentProfileUpdateRequestDto.java
@@ -1,4 +1,4 @@
-package com.team7.Idam.domain.user.dto.profile;
+package com.team7.Idam.domain.user.dto.profile.student;
 
 import com.team7.Idam.domain.user.entity.enums.Gender;
 import lombok.Data;

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/student/UpdateTagsRequestDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/student/UpdateTagsRequestDto.java
@@ -1,4 +1,4 @@
-package com.team7.Idam.domain.user.dto.profile;
+package com.team7.Idam.domain.user.dto.profile.student;
 
 import lombok.Getter;
 

--- a/Idam/src/main/java/com/team7/Idam/domain/user/entity/Company.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/entity/Company.java
@@ -37,4 +37,7 @@ public class Company {
 
     @Column(name = "profile_image", length = 255)
     private String profileImage;
+
+    @Column(name= "company_description", nullable = false, length = 255)
+    private String companyDescription;
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/entity/TagOption.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/entity/TagOption.java
@@ -7,7 +7,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "tag_option")
+@Table(
+        name = "tag_option",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"tag_name", "category_id"})
+)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/Idam/src/main/java/com/team7/Idam/domain/user/service/AuthService.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/service/AuthService.java
@@ -110,6 +110,7 @@ public class AuthService {
                 .address(request.getAddress())
                 .website(request.getWebsite())
                 .profileImage(request.getProfileImage())
+                .companyDescription("기업 소개가 없습니다.")
                 .build();
         companyRepository.save(company);
     }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/service/CompanyProfileService.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/service/CompanyProfileService.java
@@ -1,6 +1,7 @@
 package com.team7.Idam.domain.user.service;
 
-import com.team7.Idam.domain.user.dto.profile.CompanyProfileResponseDto;
+import com.team7.Idam.domain.user.dto.profile.company.CompanyProfileResponseDto;
+import com.team7.Idam.domain.user.dto.profile.company.CompanyProfileUpdateRequestDto;
 import com.team7.Idam.domain.user.entity.Company;
 import com.team7.Idam.domain.user.repository.CompanyRepository;
 import com.team7.Idam.global.util.SecurityUtil;
@@ -41,6 +42,7 @@ public class CompanyProfileService {
                 .profileImage(company.getProfileImage())
                 .email(company.getUser().getEmail())
                 .phone(company.getUser().getPhone())
+                .companyDescription(company.getCompanyDescription())
                 .build();
     }
 
@@ -82,4 +84,24 @@ public class CompanyProfileService {
         company.setProfileImage(null);
         companyRepository.save(company);
     }
+
+    /*
+        기업 프로필 정보 수정
+     */
+    public void updateCompanyProfile(Long userId, CompanyProfileUpdateRequestDto request) {
+        validateCompanyAccess(userId);
+
+        Company company = companyRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 기업을 찾을 수 없습니다."));
+
+        if(request.getCompanyDescription() != null) {
+            company.setCompanyDescription(request.getCompanyDescription());
+        }
+        if(request.getWebsite() != null) {
+            company.setWebsite(request.getWebsite());
+        }
+
+        companyRepository.save(company);
+    }
+
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/service/StudentProfileService.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/service/StudentProfileService.java
@@ -1,6 +1,6 @@
 package com.team7.Idam.domain.user.service;
 
-import com.team7.Idam.domain.user.dto.profile.*;
+import com.team7.Idam.domain.user.dto.profile.student.*;
 import com.team7.Idam.domain.user.entity.Portfolio;
 import com.team7.Idam.domain.user.entity.Student;
 import com.team7.Idam.domain.user.entity.TagOption;


### PR DESCRIPTION
## 주요 구현 사항
1. 기업 프로필 수정 API 구현
    - 기업 소개란
    - 웹사이트

2. 기업 소개란 추가
    - company DB 테이블 수정 (company_description 추가)
    - 회원가입 시 : 기업 소개란 "기업 소개가 없습니다." 기본값 설정. (nullable = false)

<br>

## 추가 구현 사항
- 태그 추가/수정 API 오류 수정.
    - 서버 재부팅 시 tag_option 데이터 중복 저장되는 오류 수정.
- dto 패키지 분할
    - student/company