### PR TITLE
refactor: DB 초기화 완료 메시지 출력용 DbReadyLogger 클래스 추가

### DIFF
--- a/Idam/src/main/java/com/team7/Idam/global/event/DbReadyLogger.java
+++ b/Idam/src/main/java/com/team7/Idam/global/event/DbReadyLogger.java
@@ -1,0 +1,29 @@
+package com.team7.Idam.global.event;
+
+import com.team7.Idam.domain.user.repository.TagCategoryRepository;
+import com.team7.Idam.domain.user.repository.TagOptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+
+@Component
+@RequiredArgsConstructor
+public class DbReadyLogger {
+
+    private final TagCategoryRepository tagCategoryRepository;
+    private final TagOptionRepository tagOptionRepository;
+
+    /**
+     * 애플리케이션이 완전히 초기화되고 DB가 모두 준비된 뒤 실행되는 메서드입니다.
+     * 여기서 DB 상태나 초기화 완료 로그를 찍을 수 있습니다.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        long categoryCount = tagCategoryRepository.count();
+        long tagCount = tagOptionRepository.count();
+
+        System.out.println("\n\n🎉 [IDam] 서버 초기화 및 DB 로딩 완료!");
+        System.out.println("🚀 이담 서비스를 시작합니다!\n");
+    }
+}

--- a/Idam/src/main/java/com/team7/Idam/jwt/JwtTokenProvider.java
+++ b/Idam/src/main/java/com/team7/Idam/jwt/JwtTokenProvider.java
@@ -18,7 +18,7 @@ public class JwtTokenProvider {
     @Value("${jwt.secret}")
     private String secret;
 
-    private final long accessTokenExpirationMillis = 1000 * 60 * 1; // 30분
+    private final long accessTokenExpirationMillis = 1000 * 60 * 30; // 30분
     private final long refreshTokenExpirationMillis = 1000L * 60 * 60 * 24 * 7; // 7일
 
     @PostConstruct


### PR DESCRIPTION
## 개요
서버 실행 시 Hibernate SQL 로그를 비활성화하더라도, 
개발자가 DB 초기화 완료 시점을 명확히 확인할 수 있도록 로그 출력 기능을 추가했습니다.

## 변경 내용
- `@EventListener(ApplicationReadyEvent.class)` 기반 `DbReadyLogger` 클래스 추가
- 서버가 완전히 실행되고 JPA, data.sql, Bean 초기화가 모두 끝난 후 다음 메시지 출력:
🎉 [IDam] 서버 초기화 및 DB 로딩 완료!
🚀 이담 서비스를 시작합니다!

## 디렉토리 구조
- `global.event.DbReadyLogger.java` 로 분리하여 관리

## 적용 이유
- Hibernate SQL 로그를 `OFF`한 상태에서도 서버/DB 준비 완료 여부를 쉽게 파악
- 초기화 시점 이후 실행되므로 안정적

## 테스트
- 서버 실행 시 로그 출력 확인

## 추가 구현 사항
- 테스트용 AccessToken 유효시간 1분 -> 30분으로 복구