### PR TITLE
refactor: 학생/기업 더미데이터에 개별 지정값 설정 및 추가 수정

### DIFF
--- a/Idam/src/main/java/com/team7/Idam/config/UserDataInitializer.java
+++ b/Idam/src/main/java/com/team7/Idam/config/UserDataInitializer.java
@@ -28,6 +28,46 @@ public class UserDataInitializer implements CommandLineRunner {
         // 카테고리 목록
         List<String> categoryNames = List.of("IT·프로그래밍", "디자인", "마케팅");
 
+        //  가상 학생 이름 리스트
+        List<String> studentNames = List.of(
+                "김지훈", "이서연", "박준영", "최지우", "정민서", "한예린", "장하준", "윤서아", "백현우", "조하늘",
+                "오유진", "남도현", "서지민", "이하은", "문지후", "송다인", "임하랑", "강시아", "배시우", "허나윤",
+                "노지아", "하채민", "전지후", "구세린", "류현우", "신다원", "고예성", "권하람", "민서준", "최가을"
+        );
+        // 30개 실제 이미지 URL (AWS S3 경로)
+        List<String> studentImages = List.of(
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/1.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/2.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/3.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/4.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/5.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/6.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/7.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/8.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/9.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/10.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/11.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/12.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/13.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/14.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/15.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/16.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/17.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/18.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/19.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/20.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/21.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/22.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/23.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/24.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/25.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/26.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/27.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/28.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/29.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/30.jpg"
+        );
+
         int studentId = 1;
 
         // 1. 학생 더미 생성
@@ -52,7 +92,7 @@ public class UserDataInitializer implements CommandLineRunner {
                 Student student = studentRepository.save(
                         Student.builder()
                                 .user(studentUser)
-                                .name("학생" + studentId)
+                                .name(studentNames.get(studentId - 1))
                                 .nickname("stud" + studentId)
                                 .schoolName("인천대학교")
                                 .major("정보통신공학과")
@@ -60,6 +100,7 @@ public class UserDataInitializer implements CommandLineRunner {
                                 .password("student1234")
                                 .gender((studentId % 2 == 0) ? Gender.FEMALE : Gender.MALE)
                                 .category(category)
+                                .profileImage(studentImages.get(studentId - 1))
                                 .build()
                 );
 
@@ -81,9 +122,41 @@ public class UserDataInitializer implements CommandLineRunner {
             }
         }
 
+        // 실제 기업 정보 리스트 (10개)
+        List<String> companyNames = List.of("(주)우아한형제들", "케이지이니시스", "젬텍", "한국멘토그래픽스", "가람디자인", "유윈디자인", "씨앤씨인터내셔널", "주식회사 진이어스", "TBWA코리아(주)", "엔비티");
+        List<String> companyImages = List.of(
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/101.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/102.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/103.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/104.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/105.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/106.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/107.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/108.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/109.jpg",
+                "https://unithon-idam.s3.ap-northeast-2.amazonaws.com/110.jpg"
+        );
+        List<String> companyWebsites = List.of(
+                "http://www.woowahan.com/", "http://www.inicis.com/", "http://gemtek.co.kr/", "https://eda.sw.siemens.com/",
+                "http://www.karamdesign.kr/", "https://www.youwindesign.com/", "http://www.cnccosmetic.com/", "http://www.geni-us.co.kr/",
+                "http://www.tbwakorea.com/", "http://nbt.com/"
+        );
+        List<String> companyDescriptions = List.of(
+                "배달의민족을 운영하는 국내 대표 배달 플랫폼 기업으로, IT를 활용한 음식 배달 서비스 혁신을 선도하고 있습니다.", // (주)우아한형제들
+                "전자결제 서비스 및 핀테크 솔루션을 제공하는 KG그룹 계열사로, 다양한 온라인 결제 인프라를 보유하고 있습니다.", // 케이지이니시스
+                "IoT와 네트워크 기술을 기반으로 무선 통신 기기 및 보안 시스템을 개발하는 전문 제조업체입니다.", // 젬텍
+                "반도체 설계 자동화(EDA) 솔루션을 제공하는 글로벌 기업 Siemens EDA의 한국 지사입니다.", // 한국멘토그래픽스
+                "공간 디자인과 전시, 브랜드 환경 구축 등을 수행하는 디자인 전문 기업으로, 창의적 컨셉 기획에 강점을 가집니다.", // 가람디자인
+                "브랜딩, UI/UX, 마케팅 등 다양한 디자인 솔루션을 제공하는 통합 디자인 에이전시입니다.", // 유윈디자인
+                "색조 화장품 ODM/OEM 전문 기업으로, 글로벌 브랜드와 협업하며 고기능성 제품을 연구 및 생산합니다.", // 씨앤씨인터내셔널
+                "디지털 헬스케어와 라이프스타일 제품을 개발하는 스타트업으로, 기술과 디자인 융합에 주력합니다.", // 주식회사 진이어스
+                "글로벌 광고대행사 TBWA의 한국 지사로, 크리에이티브 중심의 브랜드 캠페인과 마케팅 전략을 제공합니다.", // TBWA코리아(주)
+                "모바일 리워드 플랫폼 '캐시슬라이드'를 운영하며, 광고주와 사용자를 연결하는 스마트 마케팅 서비스를 제공합니다." // 엔비티
+        );
+
         // 2. 기업 더미 생성
-        for (int i = 1; i <= 3; i++) {
-            String email = String.format("company%02d@example.com", i);
+        for (int i = 0; i < 10; i++) {
+            String email = String.format("company%02d@example.com", i + 1);
             if (userRepository.findByEmail(email).isPresent()) continue;
 
             User companyUser = userRepository.save(
@@ -105,10 +178,11 @@ public class UserDataInitializer implements CommandLineRunner {
                                             ThreadLocalRandom.current().nextInt(10, 100),
                                             ThreadLocalRandom.current().nextInt(10000, 100000))
                             )
-                            .companyName("기업사" + i)
+                            .companyName(companyNames.get(i))
                             .address("서울시 강남구 테헤란로 " + (10 + i))
-                            .website("https://company" + i + ".example.com")
-                            .companyDescription("기업 소개가 없습니다.")
+                            .website(companyWebsites.get(i))
+                            .companyDescription(companyDescriptions.get(i))
+                            .profileImage(companyImages.get(i))
                             .build()
             );
         }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/matching/ScoredStudentResponseDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/matching/ScoredStudentResponseDto.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ScoredStudentResponseDto {
     private Long userId;
-    private String name;
+    private String nickname;
     private String profileImage;
     private int score;
 }

--- a/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/student/StudentPreviewResponseDto.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/dto/profile/student/StudentPreviewResponseDto.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class StudentPreviewResponseDto {
     private Long userId;
-    private String name;
+    private String nickname;
     private String profileImage;
     private List<String> tags;
     private Long categoryId;
@@ -25,7 +25,7 @@ public class StudentPreviewResponseDto {
     public static StudentPreviewResponseDto from(Student student) {
         return new StudentPreviewResponseDto(
                 student.getId(),
-                student.getName(),
+                student.getNickname(),
                 student.getProfileImage(),
                 student.getTags().stream()
                         .map(TagOption::getTagName)

--- a/Idam/src/main/java/com/team7/Idam/domain/user/service/MatchingService.java
+++ b/Idam/src/main/java/com/team7/Idam/domain/user/service/MatchingService.java
@@ -51,7 +51,7 @@ public class MatchingService {
                     .filter(tagNameSet::contains)
                     .count();
 
-            result.add(new ScoredStudentResponseDto(student.getId(), student.getName(), student.getProfileImage(), score));
+            result.add(new ScoredStudentResponseDto(student.getId(), student.getNickname(), student.getProfileImage(), score));
         }
 
         return result.stream()


### PR DESCRIPTION
## 변경 내용 요약

### 1. 학생 더미 데이터
- 각각 다른 가상 이름과 고유한 프로필 이미지 (S3 경로) 부여

### 2. 기업 더미 데이터
- 총 3개 → 10개로 확대
- 각 기업에 대해 아래 항목 실데이터 적용:
  - 실제 기업명 (예: `(주)우아한형제들`, `케이지이니시스`, `TBWA코리아(주)` 등)
  - AWS S3에 업로드된 실제 기업 로고 이미지 사용 (`companyImages`)
  - 실제 홈페이지 URL (`companyWebsites`)
  - 각 기업의 간단한 소개문구 (`companyDescriptions`)

---

## 목적
- 프론트엔드에서 실제처럼 보이는 UI/UX 시연을 위한 시각적 완성도 향상
- 추천 알고리즘 테스트 및 리스트 랜더링 시 **의미 있는 가상 데이터 제공

---

## 추가 참고
- `UserDataInitializer.java` 내에 더미 데이터 자동 생성 로직 수정
- `studentNames`, `studentImages`, `companyNames`, `companyWebsites`, `companyDescriptions` 등 리스트 기반 구성

---

## 추가 변경안
- AI 매칭 및 학생 Preview에서 이름 → 닉네임으로 반환값 변경